### PR TITLE
Patch bug in dedi

### DIFF
--- a/src/module/patches.cpp
+++ b/src/module/patches.cpp
@@ -44,6 +44,7 @@ private:
 
 	void patch_dedi() const
 	{
+		// Skip call to queryserverinfo handler in SV_ConnectionlessPacket
 		utils::hook::nop(0x4FE051, 5);
 	}
 

--- a/src/module/patches.cpp
+++ b/src/module/patches.cpp
@@ -44,6 +44,7 @@ private:
 
 	void patch_dedi() const
 	{
+		utils::hook::nop(0x4FE051, 5);
 	}
 
 	static __declspec(noreturn) void long_jump_stub(jmp_buf buf, const int value) noexcept(false)


### PR DESCRIPTION
There is a denial of service vulnerability in the dedicated binary of iw5.
It works the same way as the 'original' cbuf exploit in Quake III. That is the game uses a command argument sent by the client as part of the text that is added to the cbuf, thus enabling remote command execution. It requires a trivial patch to the mp client to take down the server, I shouldn't probably show how to do it here but every command such as `quit` can be executed.
This bug is exclusive to the dedi binary as it is the only one that has a command handler for the oob "queryserverinfo".