### PR TITLE
Bounces from all angles. Re-organize includes based on cpp core guideliness

### DIFF
--- a/src/game/scripting/context.cpp
+++ b/src/game/scripting/context.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "context_initializer.hpp"
 
 namespace game::scripting

--- a/src/game/scripting/context_initializer.cpp
+++ b/src/game/scripting/context_initializer.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "context_initializer.hpp"
 
 #include "utils/string.hpp"

--- a/src/game/scripting/event_handler.cpp
+++ b/src/game/scripting/event_handler.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "context.hpp"
 
 namespace game::scripting

--- a/src/game/scripting/executer.cpp
+++ b/src/game/scripting/executer.cpp
@@ -1,6 +1,7 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
+#include <utils/string.hpp>
+
 #include "game/game.hpp"
-#include "utils/string.hpp"
 #include "functions.hpp"
 #include "stack_isolation.hpp"
 #include "safe_executer.hpp"

--- a/src/game/scripting/functions.cpp
+++ b/src/game/scripting/functions.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "functions.hpp"
 
 namespace game::scripting

--- a/src/game/scripting/parameters.cpp
+++ b/src/game/scripting/parameters.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "context.hpp"
 
 namespace game::scripting

--- a/src/game/scripting/safe_executer.cpp
+++ b/src/game/scripting/safe_executer.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "safe_executer.hpp"
 
 #pragma warning(push)

--- a/src/game/scripting/scheduler.cpp
+++ b/src/game/scripting/scheduler.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "context.hpp"
 
 namespace game::scripting

--- a/src/game/scripting/stack_isolation.cpp
+++ b/src/game/scripting/stack_isolation.cpp
@@ -1,4 +1,4 @@
-#include "std_include.hpp"
+#include <std_include.hpp>
 #include "stack_isolation.hpp"
 
 namespace game::scripting

--- a/src/launcher/launcher.cpp
+++ b/src/launcher/launcher.cpp
@@ -1,6 +1,7 @@
 #include <std_include.hpp>
+#include <utils/nt.hpp>
+
 #include "launcher.hpp"
-#include "utils/nt.hpp"
 
 launcher::launcher()
 {

--- a/src/loader/binary_loader.cpp
+++ b/src/loader/binary_loader.cpp
@@ -1,10 +1,11 @@
 #include <std_include.hpp>
+#include <utils/nt.hpp>
+#include <utils/io.hpp>
+#include <utils/cryptography.hpp>
+#include <utils/string.hpp>
+#include <utils/compression.hpp>
+
 #include "binary_loader.hpp"
-#include "utils/nt.hpp"
-#include "utils/io.hpp"
-#include "utils/cryptography.hpp"
-#include "utils/string.hpp"
-#include "utils/compression.hpp"
 
 #define DEDI_HASH "F271C305117B79242E254E9F64BD5AA2993CAC8E57975243EBD44CD576418D20"
 

--- a/src/loader/loader.cpp
+++ b/src/loader/loader.cpp
@@ -1,7 +1,8 @@
 #include <std_include.hpp>
+#include <utils/string.hpp>
+
 #include "loader.hpp"
 #include "binary_loader.hpp"
-#include "utils/string.hpp"
 
 loader::loader(const launcher::mode mode) : mode_(mode)
 {

--- a/src/loader/loader.hpp
+++ b/src/loader/loader.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "utils/nt.hpp"
-#include "launcher/launcher.hpp"
+#include <utils/nt.hpp>
+#include <launcher/launcher.hpp>
 
 class loader final
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <std_include.hpp>
+#include "std_include.hpp"
 #include "launcher/launcher.hpp"
 #include "loader/loader.hpp"
 #include "loader/module_loader.hpp"

--- a/src/module/ceg.cpp
+++ b/src/module/ceg.cpp
@@ -1,6 +1,7 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
-#include "utils/hook.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/hook.hpp>
+
 #include "game/game.hpp"
 
 class ceg final : public module

--- a/src/module/client_command.cpp
+++ b/src/module/client_command.cpp
@@ -1,9 +1,9 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
-#include "command.hpp"
-#include "game/game.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/string.hpp>
 
-#include "utils/string.hpp"
+#include "game/game.hpp"
+#include "command.hpp"
 
 class client_command final : public module
 {

--- a/src/module/command.cpp
+++ b/src/module/command.cpp
@@ -1,8 +1,12 @@
 #include <std_include.hpp>
-#include "command.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/string.hpp>
+#include <utils/hook.hpp>
 
-#include "utils/string.hpp"
-#include "utils/hook.hpp"
+#include "game/structs.hpp"
+#include "game/game.hpp"
+
+#include "command.hpp"
 
 utils::memory::allocator command::allocator_;
 std::unordered_map<std::string, std::function<void(const command::params&)>> command::handlers;

--- a/src/module/command.cpp
+++ b/src/module/command.cpp
@@ -3,7 +3,6 @@
 #include <utils/string.hpp>
 #include <utils/hook.hpp>
 
-#include "game/structs.hpp"
 #include "game/game.hpp"
 
 #include "command.hpp"

--- a/src/module/command.hpp
+++ b/src/module/command.hpp
@@ -1,10 +1,5 @@
 #pragma once
-#include "loader/module_loader.hpp"
-
-#include "game/structs.hpp"
-#include "game/game.hpp"
-
-#include "utils/memory.hpp"
+#include <utils/memory.hpp>
 
 class command final : public module
 {

--- a/src/module/console.cpp
+++ b/src/module/console.cpp
@@ -1,5 +1,6 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
+#include <loader/module_loader.hpp>
+
 #include "game/game.hpp"
 #include "scheduler.hpp"
 

--- a/src/module/discord.cpp
+++ b/src/module/discord.cpp
@@ -1,8 +1,10 @@
 #include <std_include.hpp>
+#include <loader/module_loader.hpp>
+
 #include <discord_rpc.h>
-#include "loader/module_loader.hpp"
-#include "scheduler.hpp"
+
 #include "game/game.hpp"
+#include "scheduler.hpp"
 
 class discord final : public module
 {

--- a/src/module/dw.cpp
+++ b/src/module/dw.cpp
@@ -1,9 +1,7 @@
 #include <std_include.hpp>
-#include "dw.hpp"
-#include "utils/hook.hpp"
-#include "game/game.hpp"
-#include "utils/nt.hpp"
-#include "utils/cryptography.hpp"
+#include <utils/hook.hpp>
+#include <utils/nt.hpp>
+#include <utils/cryptography.hpp>
 
 #include "game/demonware/services/bdLSGHello.hpp"       // 7
 #include "game/demonware/services/bdStorage.hpp"        // 10
@@ -12,6 +10,9 @@
 #include "game/demonware/services/bdDML.hpp"            // 27
 #include "game/demonware/services/bdDediRSAAuth.hpp"    // 26
 #include "game/demonware/services/bdSteamAuth.hpp"      // 28
+
+#include "game/game.hpp"
+#include "dw.hpp"
 
 namespace demonware
 {

--- a/src/module/dw.hpp
+++ b/src/module/dw.hpp
@@ -1,5 +1,6 @@
 #pragma once
-#include "loader/module_loader.hpp"
+#include <loader/module_loader.hpp>
+
 #include "game/demonware/stun_server.hpp"
 #include "game/demonware/service_server.hpp"
 

--- a/src/module/fastfiles.cpp
+++ b/src/module/fastfiles.cpp
@@ -1,7 +1,8 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/hook.hpp>
+
 #include "game/game.hpp"
-#include "utils/hook.hpp"
 
 static __declspec(naked) void db_load_stub_client(game::native::XZoneInfo*, unsigned int, int)
 {

--- a/src/module/fov.cpp
+++ b/src/module/fov.cpp
@@ -1,6 +1,7 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
-#include "utils/hook.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/hook.hpp>
+
 #include "game/game.hpp"
 
 class fov final : public module

--- a/src/module/game_launcher.cpp
+++ b/src/module/game_launcher.cpp
@@ -1,7 +1,7 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
-#include "utils/nt.hpp"
-#include "utils/string.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/nt.hpp>
+#include <utils/string.hpp>
 
 class game_launcher final : public module
 {

--- a/src/module/patches.cpp
+++ b/src/module/patches.cpp
@@ -1,6 +1,7 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
-#include "utils/hook.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/hook.hpp>
+
 #include "game/game.hpp"
 
 class patches final : public module

--- a/src/module/patches.cpp
+++ b/src/module/patches.cpp
@@ -41,7 +41,7 @@ private:
 
 	void patch_mp() const
 	{
-		// Note: on SP it's already unlocked to 1000
+		// Note: on SP the max value is already 1000
 		utils::hook(0x55411F, &dvar_register_com_max_fps, HOOK_CALL).install()->quick();
 	}
 
@@ -63,9 +63,10 @@ private:
 	}
 
 	static const game::native::dvar_t* dvar_register_com_max_fps(const char* dvarName, int value,
-		int min, int /*max*/, unsigned __int16 flags, const char* description)
+		int min, int /*max*/, unsigned __int16 /*flags*/, const char* description)
 	{
-		return game::native::Dvar_RegisterInt(dvarName, value, min, 1000, flags, description);
+		return game::native::Dvar_RegisterInt(dvarName, value, min, 1000,
+			game::native::dvar_flags::DVAR_ARCHIVE, description);
 	}
 };
 

--- a/src/module/player_movement.cpp
+++ b/src/module/player_movement.cpp
@@ -328,7 +328,7 @@ void player_movement::pm_project_velocity_stub(const float* vel_in, const float*
 	const auto length_scale = std::sqrtf((vel_in[2] * vel_in[2] + length_squared_2d) /
 		(new_z * new_z + length_squared_2d));
 
-	if (player_movement::pm_bouncesAllAngles->current.enabled
+	if (player_movement::pm_bouncesAllAngles->current.enabled == true
 		|| (length_scale < 1.f || new_z < 0.f || vel_in[2] > 0.f))
 	{
 		vel_out[0] = vel_in[0] * length_scale;

--- a/src/module/player_movement.cpp
+++ b/src/module/player_movement.cpp
@@ -268,7 +268,7 @@ __declspec(naked) void player_movement::jump_get_step_height_stub()
 	{
 		push eax
 		mov eax, player_movement::jump_stepSize
-		fadd dword ptr [eax + 0xC]
+		fld dword ptr [eax + 0xC]
 		pop eax
 
 		jmp jump_get_step_height_addr
@@ -415,8 +415,8 @@ void player_movement::patch_mp()
 
 	utils::hook(0x422BE0, &player_movement::pm_crash_land_stub_mp, HOOK_CALL).install()->quick(); // PM_GroundTrace
 
-	utils::hook(0x416154, &player_movement::jump_get_step_height_stub, HOOK_JUMP).install()->quick(); // PM_StepSlideMove
-	utils::hook::nop(0x416159, 1); // Nop skipped opcode
+	utils::hook(0x41613F, &player_movement::jump_get_step_height_stub, HOOK_JUMP).install()->quick(); // PM_StepSlideMove
+	utils::hook::nop(0x416144, 1); // Nop skipped opcode
 
 	// Modify the hardcoded value of the spread with the value of jump_spreadAdd
 	utils::hook(0x4166F0, &player_movement::jump_start_stub, HOOK_JUMP).install()->quick();
@@ -457,8 +457,8 @@ void player_movement::patch_sp()
 
 	utils::hook(0x6442DF, &player_movement::pm_crash_land_stub_sp, HOOK_CALL).install()->quick(); // PM_GroundTrace
 
-	utils::hook(0x48C1F5, &player_movement::jump_get_step_height_stub, HOOK_JUMP).install()->quick(); // PM_StepSlideMove
-	utils::hook::nop(0x48C1FA, 1); // Nop skipped opcode
+	utils::hook(0x48C1DC, &player_movement::jump_get_step_height_stub, HOOK_JUMP).install()->quick(); // PM_StepSlideMove
+	utils::hook::nop(0x48C1E1, 1); // Nop skipped opcode
 
 	// Modify the hardcoded value of the spread with the value of jump_spreadAdd
 	utils::hook(0x63E90A, &player_movement::jump_start_stub, HOOK_JUMP).install()->quick();
@@ -481,7 +481,7 @@ void player_movement::post_load()
 	player_movement::dont_bounce_addr = SELECT_VALUE(0x43D933, 0x424D6C, 0x0);
 	player_movement::push_off_ladder_addr = SELECT_VALUE(0x63EA4C, 0x41686C, 0x0);
 	player_movement::jump_start_addr = SELECT_VALUE(0x63E910, 0x4166F6, 0x0);
-	player_movement::jump_get_step_height_addr = SELECT_VALUE(0x48C1FB, 0x41615A, 0x0);
+	player_movement::jump_get_step_height_addr = SELECT_VALUE(0x48C1E2, 0x416145, 0x0);
 
 	player_movement::pm_bounces = game::native::Dvar_RegisterBool("pm_bounces", false,
 		game::native::dvar_flags::DVAR_CODINFO, "CoD4 Bounces");

--- a/src/module/player_movement.hpp
+++ b/src/module/player_movement.hpp
@@ -24,6 +24,7 @@ private:
 	static DWORD dont_bounce_addr;
 	static DWORD push_off_ladder_addr;
 	static DWORD jump_start_addr;
+	static DWORD jump_get_step_height_addr;
 
 	static void pm_weapon_use_ammo(game::native::playerState_s* ps, const game::native::Weapon weapon,
 		bool is_alternate, int amount, game::native::PlayerHandIndex hand);
@@ -70,8 +71,7 @@ private:
 	static void pm_crash_land_stub_mp();
 	static void pm_crash_land_stub_sp();
 
-	static bool jump_get_step_height_stub_mp(game::native::playerState_s* ps, const float* origin, float* stepSize);
-	static void jump_get_step_height_stub_sp();
+	static void jump_get_step_height_stub();
 
 	static void jump_start_stub();
 

--- a/src/module/player_movement.hpp
+++ b/src/module/player_movement.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include "loader/module_loader.hpp"
 
 class player_movement final : public module
 {
@@ -15,6 +14,7 @@ private:
 	static const game::native::dvar_t* jump_stepSize;
 	static const game::native::dvar_t* jump_spreadAdd;
 	static const game::native::dvar_t* pm_bounces;
+	static const game::native::dvar_t* pm_bouncesAllAngles;
 	static const game::native::dvar_t* pm_playerEjection;
 	static const game::native::dvar_t* pm_playerCollision;
 	static const game::native::dvar_t* pm_rocketJump;
@@ -74,6 +74,8 @@ private:
 	static void jump_get_step_height_stub_sp();
 
 	static void jump_start_stub();
+
+	static void pm_project_velocity_stub(const float* vel_in, const float* normal, float* vel_out);
 
 	static void patch_mp();
 	static void patch_sp();

--- a/src/module/scheduler.cpp
+++ b/src/module/scheduler.cpp
@@ -1,8 +1,10 @@
 #include <std_include.hpp>
-#include "scheduler.hpp"
-#include "utils/string.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/string.hpp>
+#include <utils/hook.hpp>
+
 #include "game/game.hpp"
-#include "utils/hook.hpp"
+#include "scheduler.hpp"
 
 std::mutex scheduler::mutex_;
 std::queue<std::pair<std::string, int>> scheduler::errors_;

--- a/src/module/scheduler.hpp
+++ b/src/module/scheduler.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include "loader/module_loader.hpp"
 #include "utils/concurrent_list.hpp"
 
 class scheduler final : public module

--- a/src/module/scripting.cpp
+++ b/src/module/scripting.cpp
@@ -1,7 +1,8 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
-#include "utils/hook.hpp"
-#include "utils/io.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/hook.hpp>
+#include <utils/io.hpp>
+
 #include "game/scripting/context.hpp"
 #include "scheduler.hpp"
 

--- a/src/module/security.cpp
+++ b/src/module/security.cpp
@@ -1,7 +1,8 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/hook.hpp>
+
 #include "game/game.hpp"
-#include "utils/hook.hpp"
 
 class security final : public module
 {

--- a/src/module/steam_proxy.cpp
+++ b/src/module/steam_proxy.cpp
@@ -1,10 +1,12 @@
 #include <std_include.hpp>
-#include "loader/module_loader.hpp"
-#include "game/game.hpp"
-#include "utils/nt.hpp"
+#include <loader/module_loader.hpp>
+#include <utils/nt.hpp>
+#include <utils/string.hpp>
+
 #include "steam/steam.hpp"
 #include "steam/interface.hpp"
-#include "utils/string.hpp"
+
+#include "game/game.hpp"
 #include "scheduler.hpp"
 
 class steam_proxy final : public module

--- a/src/module/test_clients.cpp
+++ b/src/module/test_clients.cpp
@@ -1,9 +1,10 @@
 #include <std_include.hpp>
+#include <loader/module_loader.hpp>
+#include <utils/hook.hpp>
 
+#include "game/game.hpp"
 #include "test_clients.hpp"
 #include "command.hpp"
-
-#include "utils/hook.hpp"
 
 bool test_clients::can_add()
 {

--- a/src/module/test_clients.hpp
+++ b/src/module/test_clients.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#include "loader/module_loader.hpp"
-#include "game/game.hpp"
 
 class test_clients final : public module
 {

--- a/src/std_include.cpp
+++ b/src/std_include.cpp
@@ -1,4 +1,4 @@
-#include <std_include.hpp>
+#include "std_include.hpp"
 
 #pragma comment(linker, "/merge:.data=.cld")
 #pragma comment(linker, "/merge:.rdata=.clr")
@@ -11,24 +11,25 @@
 #pragma bss_seg(".payload")
 char payload_data[BINARY_PAYLOAD_SIZE];
 
-extern "C" {
-int s_read_arc4random(void*, size_t)
+extern "C"
 {
-	return -1;
-}
+	int s_read_arc4random(void*, size_t)
+	{
+		return -1;
+	}
 
-int s_read_getrandom(void*, size_t)
-{
-	return -1;
-}
+	int s_read_getrandom(void*, size_t)
+	{
+		return -1;
+	}
 
-int s_read_urandom(void*, size_t)
-{
-	return -1;
-}
+	int s_read_urandom(void*, size_t)
+	{
+		return -1;
+	}
 
-int s_read_ltm_rng(void*, size_t)
-{
-	return -1;
-}
+	int s_read_ltm_rng(void*, size_t)
+	{
+		return -1;
+	}
 }

--- a/src/utils/io.cpp
+++ b/src/utils/io.cpp
@@ -53,7 +53,7 @@ namespace utils::io
 			if (size > -1)
 			{
 				data->resize(static_cast<uint32_t>(size));
-				stream.read(const_cast<char*>(data->data()), size);
+				stream.read(data->data(), size);
 				stream.close();
 				return true;
 			}

--- a/src/utils/memory.hpp
+++ b/src/utils/memory.hpp
@@ -42,13 +42,13 @@ namespace utils
 		static void* allocate(size_t length);
 
 		template <typename T>
-		static inline T* allocate()
+		static T* allocate()
 		{
 			return allocate_array<T>(1);
 		}
 
 		template <typename T>
-		static inline T* allocate_array(const size_t count = 1)
+		static T* allocate_array(const size_t count = 1)
 		{
 			return static_cast<T*>(allocate(count * sizeof(T)));
 		}

--- a/src/utils/nt.cpp
+++ b/src/utils/nt.cpp
@@ -228,7 +228,7 @@ namespace utils::nt
 
 	void relaunch_self()
 	{
-		const utils::nt::library self;
+		const library self;
 
 		STARTUPINFOA startup_info;
 		PROCESS_INFORMATION process_info;


### PR DESCRIPTION
Apart from the addition of a new dvar to force bounces from all angles (& making maxfps archive)
I reorganized most includes and whenever it was appropriate I used the <> brackets instead of ""
because the compiler uses different search algorithms to find the header files.
This is according to the cpp core guidelines and makes it easier to debug include errors if they should arise in the future.

https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rs-incform